### PR TITLE
Set TMPDIR environment dynamically from header

### DIFF
--- a/mod_reset.h
+++ b/mod_reset.h
@@ -26,6 +26,7 @@ typedef struct {
         apr_table_t   *php_ini;
         char          *admin;
         char          *docroot;
+        char          *tmpdir;
         int           nheaders;
 #ifdef MOD_RUID2
         char          *ruid_uid;


### PR DESCRIPTION
Set TMPDIR environment dynamically from header. This is needed for many content management systems, like wordpress, joomla, etc. They are checking tmp directory using `sys_get_temp_dir()`, which calls `getenv("TMPDIR")`.
@tonyspa
