### PR TITLE
Add option to compile without PHP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 APXS = apxs
 SOURCES = mod_reset.c
 INCLUDES = /usr/include/php/main /usr/include/php/Zend /usr/include/php/TSRM
-FLAGS = MOD_RUID2
 
 main:
 	$(APXS) -c -i $(foreach i, $(INCLUDES), -I$i) $(SOURCES)
 ruid:
-	$(APXS) $(foreach m, $(FLAGS), -D$m) -c -i $(foreach i, $(INCLUDES), -I$i) $(SOURCES)
+	$(APXS) $(foreach m, MOD_RUID2, -D$m) -c -i $(foreach i, $(INCLUDES), -I$i) $(SOURCES)
+nophp:
+	$(APXS) $(foreach m, NO_PHP, -D$m) -c -i $(SOURCES)
 clean:
 	rm mod_reset.o mod_reset.slo mod_reset.lo mod_reset.la

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Compile
 ```
 make
 make ruid (with mod_ruid2 support)
+make nophp (without php support)
 make clean
 ```
 

--- a/mod_reset.c
+++ b/mod_reset.c
@@ -15,6 +15,7 @@ static int reset_handler(request_rec *r)
         core_server_config *core = ap_get_module_config(r->server->module_config, &core_module);
 #endif
         if (conf->enable) {
+#ifndef NO_PHP
                 apr_array_header_t *arr = (apr_array_header_t *) apr_table_elts(conf->php_ini);
                 apr_table_entry_t *ini = (apr_table_entry_t *) arr->elts;
 
@@ -43,6 +44,7 @@ static int reset_handler(request_rec *r)
                         ruid->ruid_gid = ap_uname2id(ruid_uid_header);
                 }
 #endif
+#endif
 
                 // Setting DocumentRoot
                 char *docroot = (char *) apr_table_get(r->headers_in, conf->docroot);
@@ -59,6 +61,7 @@ static int reset_handler(request_rec *r)
                         return HTTP_FORBIDDEN;
                 }
 
+#ifndef NO_PHP
                // Set TMPDIR environment variable
                char *tmpdir = (char *) apr_table_get(r->headers_in, conf->tmpdir);
                if (tmpdir && ap_is_directory(r->pool, tmpdir)) {
@@ -68,6 +71,7 @@ static int reset_handler(request_rec *r)
                } else {
                    ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "TMPDIR directory does not exist, check headers!");
                }
+#endif
 
                 // Setting ServerAdmin
                 char *admin = (char *) apr_table_get(r->headers_in, conf->admin);

--- a/mod_reset.h
+++ b/mod_reset.h
@@ -1,11 +1,12 @@
 #define MODULE_NAME "reset"
 #define CORE_PRIVATE
 #include <ap_config.h>
-#include <php_version.h>
 #include <httpd.h>
 #include <http_config.h>
 #include <http_core.h>
 #include <http_log.h>
+#ifndef NO_PHP
+#include <php_version.h>
 #include <zend.h>
 #if PHP_MAJOR_VERSION >= 7
 #include <zend_sort.h>
@@ -16,6 +17,7 @@
 #include <zend_ini.h>
 #include <zend_alloc.h>
 #include <zend_operators.h>
+#endif
 
 #if AP_SERVER_MINORVERSION_NUMBER == 2
 #define APACHE_22


### PR DESCRIPTION
Add option to compile without PHP support. This is needed for instance for `mod_lsapi` (CloudLinux).